### PR TITLE
fixes mattgj/alexa-skills#9

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ var express 	= require('express'),
 	alexa = new AlexaSkills({
 		express: app, // required
 		route: "/", // optional, defaults to "/"
+		enableCertificateValidation: true, // optional, defaults to true, disable for local testing
 		applicationId: "your_alexa_app_id" // optional, but recommended. If you do not set this leave it blank
 	});
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,20 @@
 module.exports = function(options) {
 
-    var RequestValidator = require('./request-validator'),
-        jsonParser = require('body-parser').json(),
+    var jsonParser = require('body-parser').json(),
         app = options.express,
         route = options.route || "/",
         appId = options.applicationId || "",
+        enableCertificateValidation = options.enableCertificateValidation || true,
         launchCallback = null,
         endedCallback = null,
+        middleware = [],
         intents = {};
 
-    app.post(route, jsonParser, RequestValidator, function(req, res) {
+    if (enableCertificateValidation) {
+      middleware.push(require('./request-validator'))
+    }
+
+    app.post(route, jsonParser, middleware, function(req, res) {
 
         if(req.body.session.application.applicationId == appId || !appId.length) {
 


### PR DESCRIPTION
This introduces a new option `enableCertificateValidation` which defaults to `true` (because we want to be sure by default) but makes it very easy to disable certificate validation during local testing.  This also updates the README to set the value to the default in the sample in order to document it.